### PR TITLE
feat: make content scripts load when a specific meeting is being joined

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -15,7 +15,7 @@
   },
   "content_scripts": [
     {
-      "matches": ["https://meet.google.com/*"],
+      "matches": ["https://meet.google.com/*-*-*"],
       "js": ["scripts/content.js"]
     }
   ],


### PR DESCRIPTION
Slightly adjusted the pattern for the URL on which content scripts should be loaded.